### PR TITLE
fixed error: ‘usleep’ was not declared in this scope

### DIFF
--- a/c_src/oracle/OracleDBOperation.cpp
+++ b/c_src/oracle/OracleDBOperation.cpp
@@ -24,6 +24,7 @@
 #include "OracleDBOperation.h"
 #include "../base/ConnectionPool.h"
 #include "../util/EiEncoder.h"
+#include <unistd.h>
 
 static const char* STMT_NULL_ERROR = "fail to get stmt";
 


### PR DESCRIPTION
Added: #include <unistd.h> to OracleDBOperation.cpp to fix error: c_src/oracle/OracleDBOperation.cpp:89:23: error: ‘usleep’ was not declared in this scope
